### PR TITLE
Alignment mode changes

### DIFF
--- a/docs/cnvs.md
+++ b/docs/cnvs.md
@@ -41,6 +41,7 @@ Read alignment options (if using --align):
   --interleaved         FASTA/FASTQ file in -1 are paired and contain forward AND reverse reads
   -s {very-fast,fast,sensitive,very-sensitive}
                         Alignment speed/sensitivity (very-sensitive)
+  -m {local,global}     Global/local read alignment (local)
   -n MAX_READS          # reads to use from input file(s) (use all)
   -t THREADS            Number of threads to use (1)
 

--- a/docs/snvs.md
+++ b/docs/snvs.md
@@ -41,6 +41,7 @@ Read alignment options (if using --align):
   --interleaved         FASTA/FASTQ file in -1 are paired and contain forward AND reverse reads
   -s {very-fast,fast,sensitive,very-sensitive}
                         Bowtie2 alignment speed/sensitivity (very-sensitive)
+  -m {local,global}     Global/local read alignment (global)
   -n MAX_READS          # reads to use from input file(s) (use all)
   -t THREADS            Number of threads to use (1)
 

--- a/midas/run/genes.py
+++ b/midas/run/genes.py
@@ -120,7 +120,8 @@ def pangenome_align(args):
 	command += '-x %s ' % '/'.join([args['outdir'], 'genes/temp/pangenomes']) # index
 	if args['max_reads']: command += '-u %s ' % args['max_reads'] # max num of reads
 	if args['trim']: command += '--trim3 %s ' % args['trim'] # trim 3'
-	command += '--%s-local ' % args['speed'] #   speed/sensitivity
+	command += '--%s' % args['speed'] # alignment speed
+	command += '-local ' if args['mode'] == 'local' else ' ' # global/local alignment
 	command += '--threads %s ' % args['threads'] #   threads
 	command += '-f ' if args['file_type'] == 'fasta' else '-q ' # input type
 	if args['m2']: # -1 and -2 contain paired reads

--- a/midas/run/snps.py
+++ b/midas/run/snps.py
@@ -102,7 +102,8 @@ def genome_align(args):
 	command += '-x %s ' % '/'.join([args['outdir'], 'snps/temp/genomes']) # index
 	if args['max_reads']: command += '-u %s ' % args['max_reads'] # max num of reads
 	if args['trim']: command += '--trim3 %s ' % args['trim'] # trim 3'
-	command += '--%s-local ' % args['speed'] # speed/sensitivity
+	command += '--%s' % args['speed'] # alignment speed
+	command += '-local ' if args['mode'] == 'local' else ' ' # global/local alignment
 	command += '--threads %s ' % args['threads'] 
 	command += '-f ' if args['file_type'] == 'fasta' else '-q ' # input type
 	if args['m2']: # -1 and -2 contain paired reads


### PR DESCRIPTION
-switch back to global alignment in snps module; makes program consistent with versions <= 1.2.2
-genes module has always used local alignment, so no changes here
-added option `-m` in run_midas.py snps|genes to choose between global/local read alignment
-updated help text and examples to reflect these changes