### PR TITLE
Change shebang in run_midas.py

### DIFF
--- a/scripts/run_midas.py
+++ b/scripts/run_midas.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 # MIDAS: Metagenomic Intra-species Diversity Analysis System
 # Copyright (C) 2015 Stephen Nayfach


### PR DESCRIPTION
Hello. Recently systems have been adopting python 3 as the default, therefore specifying python2 in the shebang will avoid using the wrong python version.